### PR TITLE
Add Functional Interface Example

### DIFF
--- a/src/main/java/attacktive/jkit/functional/ShortToByteFunctionJava.java
+++ b/src/main/java/attacktive/jkit/functional/ShortToByteFunctionJava.java
@@ -1,0 +1,6 @@
+package attacktive.jkit.functional;
+
+@FunctionalInterface
+interface ShortToByteFunctionJava {
+	byte applyAsByte(short s);
+}

--- a/src/main/kotlin/attacktive/jkit/functional/ShortToByteFunctionKotlin.kt
+++ b/src/main/kotlin/attacktive/jkit/functional/ShortToByteFunctionKotlin.kt
@@ -1,0 +1,5 @@
+package attacktive.jkit.functional
+
+fun interface ShortToByteFunctionKotlin {
+	fun applyAsByte(s: Short): Byte
+}

--- a/src/test/java/attacktive/jkit/functional/TestFunctionalJava.java
+++ b/src/test/java/attacktive/jkit/functional/TestFunctionalJava.java
@@ -1,0 +1,37 @@
+package attacktive.jkit.functional;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class TestFunctionalJava {
+	@Test
+	void testTransformArray() {
+		byte[] expectedArray = { (byte)2, (byte)4, (byte)6 };
+
+		short[] array = { (short)1, (short)2, (short)3 };
+		byte[] transformedArray = transformArrayJava(array, s -> (byte)(s * 2));
+		assertArrayEquals(expectedArray, transformedArray);
+
+		transformedArray = transformArrayKotlin(array, s -> (byte)(s * 2));
+		assertArrayEquals(expectedArray, transformedArray);
+	}
+
+	private byte[] transformArrayJava(short[] array, ShortToByteFunctionJava function) {
+		byte[] transformedArray = new byte[array.length];
+		for (int i = 0; i < array.length; i++) {
+			transformedArray[i] = function.applyAsByte(array[i]);
+		}
+
+		return transformedArray;
+	}
+
+	private byte[] transformArrayKotlin(short[] array, ShortToByteFunctionKotlin function) {
+		byte[] transformedArray = new byte[array.length];
+		for (int i = 0; i < array.length; i++) {
+			transformedArray[i] = function.applyAsByte(array[i]);
+		}
+
+		return transformedArray;
+	}
+}

--- a/src/test/kotlin/attacktive/jkit/functional/TestFunctionalKotlin.kt
+++ b/src/test/kotlin/attacktive/jkit/functional/TestFunctionalKotlin.kt
@@ -1,0 +1,36 @@
+package attacktive.jkit.functional
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+internal class TestFunctionalKotlin {
+	@Test
+	fun testTransformArray() {
+		val expectedArray = byteArrayOf(2.toByte(), 4.toByte(), 6.toByte())
+
+		val array = shortArrayOf(1.toShort(), 2.toShort(), 3.toShort())
+		var transformedArray = transformArrayJava(array) { s: Short -> (s * 2).toByte() }
+		Assertions.assertArrayEquals(expectedArray, transformedArray)
+
+		transformedArray = transformArrayKotlin(array) { s: Short -> (s * 2).toByte() }
+		Assertions.assertArrayEquals(expectedArray, transformedArray)
+	}
+
+	private fun transformArrayJava(array: ShortArray, function: ShortToByteFunctionJava): ByteArray {
+		val transformedArray = ByteArray(array.size)
+		for (i in array.indices) {
+			transformedArray[i] = function.applyAsByte(array[i])
+		}
+
+		return transformedArray
+	}
+
+	private fun transformArrayKotlin(array: ShortArray, function: ShortToByteFunctionKotlin): ByteArray {
+		val transformedArray = ByteArray(array.size)
+		for (i in array.indices) {
+			transformedArray[i] = function.applyAsByte(array[i])
+		}
+
+		return transformedArray
+	}
+}


### PR DESCRIPTION
The example is taken from [Baeldung](https://www.baeldung.com/java-8-functional-interfaces).

It simply implements [the example on Baeldung](https://www.baeldung.com/java-8-functional-interfaces#Primitive) both in Java and Kotlin, invoke the function across language.